### PR TITLE
[WIP] Register service worker by using PWA-WP plugin's prototype API.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .sass-cache/
+**/pwp-serviceworker.js

--- a/Classes/class-init.php
+++ b/Classes/class-init.php
@@ -129,23 +129,21 @@ class Init {
 	 */
 	public function default_settings() {
 		$options = get_option( pwp_settings()->option_key, false );
-		if ( $options ) {
-			return;
+		if ( ! $options ) {
+			update_option( pwp_settings()->option_key, [
+				'installable-enabled'       => '1',
+				'manifest-name'             => get_bloginfo( 'name' ),
+				'manifest-short-name'       => str_replace( ' ', '', get_bloginfo( 'name' ) ),
+				'manifest-starturl'         => './',
+				'manifest-description'      => get_bloginfo( 'description' ),
+				'manifest-display'          => 'standalone',
+				'manifest-orientation'      => 'portrait',
+				'manifest-theme-color'      => '#000000',
+				'manifest-background-color' => '#ffffff',
+				'offline-enabled'           => 1,
+				'offline-content'           => '',
+			] );
 		}
-
-		update_option( pwp_settings()->option_key, [
-			'installable-enabled'       => '1',
-			'manifest-name'             => get_bloginfo( 'name' ),
-			'manifest-short-name'       => str_replace( ' ', '', get_bloginfo( 'name' ) ),
-			'manifest-starturl'         => './',
-			'manifest-description'      => get_bloginfo( 'description' ),
-			'manifest-display'          => 'standalone',
-			'manifest-orientation'      => 'portrait',
-			'manifest-theme-color'      => '#000000',
-			'manifest-background-color' => '#ffffff',
-			'offline-enabled'           => 1,
-			'offline-content'           => '',
-		] );
 
 		pwp_manifest_regenerate();
 		pwp_serviceworker_regenerate();

--- a/Classes/class-serviceworker.php
+++ b/Classes/class-serviceworker.php
@@ -54,14 +54,16 @@ class Serviceworker {
 	}
 
 	public function add_to_header() {
-	    $scope = wp_json_encode( site_url( '/', 'relative' ) );
+		$scope = wp_json_encode( site_url( '/', 'relative' ) );
 		?>
 		<script type="text/javascript" id="serviceworker">
-            if ( $serviceWorkersRegister[ <?php echo $scope; ?> ] ) {
-	            $serviceWorkersRegister[ <?php echo $scope; ?> ]
-		            .then( registration => console.log( 'Success:', registration ) )
-		            .catch( error => console.error( 'Error:', error ) );
-            }
+			window.addEventListener('load', function() {
+				if ( navigator.serviceWorker.getRegistration( <?php echo $scope; ?> ) ) {
+					navigator.serviceWorker.getRegistration( <?php echo $scope; ?> )
+						.then( registration => console.log( 'Success:', registration ) )
+						.catch( error => console.error( 'Error:', error ) );
+				}
+			} );
 		</script>
 		<?php
 	}
@@ -107,6 +109,10 @@ class Serviceworker {
 		 */
 		$time    = time();
 		$content = str_replace( '{{time}}', $time, $content );
+
+		// Wrap content into IIFE.
+		$content = "( function() {\n" . $content . "} )();\n";
+
 		pwp_delete( $this->sw_path );
 		$save = pwp_put_contents( $this->sw_path, $content );
 		if ( ! $save ) {

--- a/Classes/class-serviceworker.php
+++ b/Classes/class-serviceworker.php
@@ -54,29 +54,14 @@ class Serviceworker {
 	}
 
 	public function add_to_header() {
+	    $scope = wp_json_encode( site_url( '/', 'relative' ) );
 		?>
 		<script type="text/javascript" id="serviceworker">
-			<?php
-			if ( pwp_get_setting( 'pwp-force-deregister-sw' ) ) {
-			?>
-			if ('serviceWorker' in navigator) {
-				navigator.serviceWorker.getRegistrations().then(function (registrations) {
-					registrations.forEach(function (registration) {
-						if (registration.active.scriptURL !== window.location.origin + '<?php echo pwp_register_url( $this->sw_url ); ?>') {
-							registration.unregister().then(function (boolean) {
-								if (boolean) {
-									console.log(registration.active.scriptURL + ' unregistered');
-								} else {
-									console.log(registration.active.scriptURL + ' unregistration failed');
-								}
-							});
-						}
-					});
-				});
-			}
-			<?php
-			}
-			?>
+            if ( $serviceWorkersRegister[ <?php echo $scope; ?> ] ) {
+	            $serviceWorkersRegister[ <?php echo $scope; ?> ]
+		            .then( registration => console.log( 'Success:', registration ) )
+		            .catch( error => console.error( 'Error:', error ) );
+            }
 		</script>
 		<?php
 	}

--- a/Classes/class-status.php
+++ b/Classes/class-status.php
@@ -56,9 +56,6 @@ class Status {
 			}
 			pwp_settings()->add_message( $section, "pwp_intro_stats_$key", $vals['title'], $html );
 		}
-
-		pwp_settings()->add_checkbox( $section, 'pwp-force-deregister-sw', __( 'Unregister all other serviceworkers', 'pwp' ), false );
-
 	}
 
 	public function settings_logs() {

--- a/progressive-wordpress.php
+++ b/progressive-wordpress.php
@@ -11,6 +11,9 @@ Text Domain: pwp
 Domain Path: /languages
  */
 
+define( 'PROGRESSIVE_WP_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'PROGRESSIVE_WP_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
 global $wp_version;
 if ( version_compare( $wp_version, '4.7', '<' ) || version_compare( PHP_VERSION, '5.4', '<' ) ) {
 	function pwp_compatability_warning() {


### PR DESCRIPTION
This PR modifies the files to use PWA-WP plugin's prototype API for registering the service worker.

Changes:
- Remove the JS logic for registering Service Worker;
- Modify the path where the SW file is generated to be located within the plugin's folder;
- Fix activation hook to regenerate SW file even if the options exist -- looks like the deactivation hook is not removing the options;

Todo:
- Once the Prototype gets merged then perhaps add the PWA-WP plugin to `package.json`.